### PR TITLE
Clear flags for the temporal string stream to avoid conversion errors.

### DIFF
--- a/src/Value.cpp
+++ b/src/Value.cpp
@@ -811,6 +811,7 @@ namespace JsonBox {
 							}
 
 							if (noUnicodeError) {
+								tmpSs.clear();
 								tmpSs.str("");
 								tmpSs << std::hex << tmpStr;
 								tmpSs >> tmpInt;


### PR DESCRIPTION
String stream flags were not cleared and this was causing all the
unicode characters of a string to be converted as the first encountered
unicode character.

Example:
"first á followed by é" -> was being encoded as "first á followed by á"
