### PR TITLE
Modernize build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,33 @@ cmake_minimum_required(VERSION 2.6)
 
 project(JsonBox)
 
-# glob all sources
-file(GLOB_RECURSE JSONBOX_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src" "src/*.cpp")
-file(GLOB_RECURSE JSONBOX_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include" "include/*.h")
+set(JSONBOX_SOURCES
+  src/JsonWritingError.cpp
+  src/Value.cpp
+  src/Array.cpp
+  src/SolidusEscaper.cpp
+  src/Escaper.cpp
+  src/Indenter.cpp
+  src/IndentCanceller.cpp
+  src/JsonParsingError.cpp
+  src/Convert.cpp
+  src/Object.cpp
+)
+set(JSONBOX_HEADERS
+  include/JsonBox/Array.h
+  include/JsonBox/Convert.h
+  include/JsonBox/Escaper.h
+  include/JsonBox/Grammar.h
+  include/JsonBox/IndentCanceller.h
+  include/JsonBox/Indenter.h
+  include/JsonBox/JsonParsingError.h
+  include/JsonBox/JsonWritingError.h
+  include/JsonBox/Object.h
+  include/JsonBox/OutputFilter.h
+  include/JsonBox/SolidusEscaper.h
+  include/JsonBox/Value.h
+  include/JsonBox.h
+)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(JsonBox)
+
+include(GenerateExportHeader)
+
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 
 set(JSONBOX_SOURCES
   src/JsonWritingError.cpp
@@ -28,13 +33,16 @@ set(JSONBOX_HEADERS
   include/JsonBox/SolidusEscaper.h
   include/JsonBox/Value.h
   include/JsonBox.h
+  ${CMAKE_CURRENT_BINARY_DIR}/Export.h
 )
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-# setup static archive
+# build library
 set(CMAKE_DEBUG_POSTFIX "_d")
 add_library(JsonBox ${JSONBOX_SOURCES} ${JSONBOX_HEADERS})
+
+generate_export_header(JsonBox EXPORT_FILE_NAME Export.h)
 
 # install
 install(TARGETS JsonBox
@@ -43,7 +51,10 @@ install(TARGETS JsonBox
   LIBRARY DESTINATION lib${LIB_SUFFIX}
   RUNTIME DESTINATION bin
 )
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION "include" COMPONENT dev)
+install(FILES ${JSONBOX_HEADERS}
+  COMPONENT dev
+  DESTINATION include
+)
 
 # examples
 add_executable(example1 "${CMAKE_CURRENT_SOURCE_DIR}/examples/main.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,25 +36,43 @@ set(JSONBOX_HEADERS
   ${CMAKE_CURRENT_BINARY_DIR}/Export.h
 )
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
-
 # build library
 set(CMAKE_DEBUG_POSTFIX "_d")
 add_library(JsonBox ${JSONBOX_SOURCES} ${JSONBOX_HEADERS})
 
 generate_export_header(JsonBox EXPORT_FILE_NAME Export.h)
 
+target_include_directories(JsonBox PRIVATE
+  ${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_BINARY_DIR}
+)
+target_include_directories(JsonBox SYSTEM INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+)
+
+export(TARGETS JsonBox
+  FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+)
+
 # install
 install(TARGETS JsonBox
   COMPONENT lib
+  EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib${LIB_SUFFIX}
   LIBRARY DESTINATION lib${LIB_SUFFIX}
   RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
 install(FILES ${JSONBOX_HEADERS}
   COMPONENT dev
   DESTINATION include
 )
+install(EXPORT ${PROJECT_NAME}
+  DESTINATION lib${LIB_SUFFIX}/cmake
+  FILE ${PROJECT_NAME}Config.cmake
+)
+
 
 # examples
 add_executable(example1 "${CMAKE_CURRENT_SOURCE_DIR}/examples/main.cpp")

--- a/include/JsonBox/Array.h
+++ b/include/JsonBox/Array.h
@@ -7,13 +7,15 @@
 #include "Value.h"
 
 namespace JsonBox {
+	JSONBOX_EXPORT std::ostream &operator<<(std::ostream &output, const Array &a);
+
 	/**
 	 * Represents an array of values in JSON. It's a vector with added methods.
 	 * So it can be used the same way as a standard STL vector, but can be more
 	 * easily output in a stream.
 	 * @see JsonBox::Value
 	 */
-	class Array {
+	class JSONBOX_EXPORT Array {
 	public:
 		typedef std::vector<Value> container;
 		typedef container::value_type value_type;

--- a/include/JsonBox/Object.h
+++ b/include/JsonBox/Object.h
@@ -8,13 +8,15 @@
 #include "Value.h"
 
 namespace JsonBox {
+	JSONBOX_EXPORT std::ostream &operator<<(std::ostream& output, const Object& o);
+
 	/**
 	 * Represents a JSON object. It's a map with added methods. So the JSON
 	 * object type can be used the same way as a standard STL map of string and
 	 * Value, but can be more easily output in a stream.
 	 * @see JsonBox::Value
 	 */
-	class Object {
+	class JSONBOX_EXPORT Object {
 	public:
 		typedef std::map<std::string, Value> container;
 		typedef container::key_type key_type;

--- a/include/JsonBox/Value.h
+++ b/include/JsonBox/Value.h
@@ -4,9 +4,15 @@
 #include <string>
 #include <iostream>
 
+#include "Export.h"
+
+
 namespace JsonBox {
 	class Array;
 	class Object;
+	class Value;
+
+	JSONBOX_EXPORT std::ostream &operator<<(std::ostream &output, const Value &v);
 
 	/**
 	 * Represents a json value. Can be a string, an integer, a floating point
@@ -18,7 +24,7 @@ namespace JsonBox {
 	 * @see JsonBox::Array
 	 * @see JsonBox::Object
 	 */
-	class Value {
+	class JSONBOX_EXPORT Value {
 		/**
 		 * Output operator overload. Outputs the value as valid JSON. Does not
 		 * do any indentation.


### PR DESCRIPTION
Add support for building shared libraries. Add ABI export decoration (fixes #24). Create CMake exported targets.

This contains all the necessary bits for shared libraries to be fully and properly supported. It also creates a CMake package configuration file so that JsonBox can be very easily used by CMake-based consumers, even from a JsonBox build directory.

It does, however, bump the minimum required CMake version to 2.8.12.