### PR TITLE
Modified to don't need libstd++ and fixed an install issue.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,16 +18,6 @@ set(JSONBOX_SOURCES
   src/Convert.cpp
 )
 set(JSONBOX_HEADERS
-  include/JsonBox/Convert.h
-  include/JsonBox/Escaper.h
-  include/JsonBox/Grammar.h
-  include/JsonBox/IndentCanceller.h
-  include/JsonBox/Indenter.h
-  include/JsonBox/JsonParsingError.h
-  include/JsonBox/JsonWritingError.h
-  include/JsonBox/OutputFilter.h
-  include/JsonBox/SolidusEscaper.h
-  include/JsonBox/Value.h
   include/JsonBox.h
   ${CMAKE_CURRENT_BINARY_DIR}/Export.h
 )
@@ -64,6 +54,7 @@ install(FILES ${JSONBOX_HEADERS}
   COMPONENT dev
   DESTINATION include
 )
+install(DIRECTORY include/ DESTINATION include)
 install(EXPORT ${PROJECT_NAME}
   DESTINATION lib${LIB_SUFFIX}/cmake
   FILE ${PROJECT_NAME}Config.cmake

--- a/include/JsonBox/Convert.h
+++ b/include/JsonBox/Convert.h
@@ -1,12 +1,13 @@
 #ifndef JB_CONVERTER_H
 #define JB_CONVERTER_H
 
+#include <vector>
 #include <string>
 #include <stdint.h>
 
 namespace JsonBox {
 	
-	typedef std::basic_string<int32_t> String32;
+	typedef std::vector<int32_t> String32;
 
 	/**
 	 * This class is used to encode/decode/transcode UTF8, 16 and 32.


### PR DESCRIPTION
Replaced "basic_string" with "vector" to don't need libstd++.
Fixed an issue where install would flatten the JsonBox directory.