### PR TITLE
added Object and Array to getToString()

### DIFF
--- a/src/Value.cpp
+++ b/src/Value.cpp
@@ -476,34 +476,39 @@ namespace JsonBox {
 	}
 
 	const std::string Value::getToString() const {
-		if (type == STRING) {
-			return  *data.stringValue;
+	switch (type) {
+		case STRING:
+			return *data.stringValue;
 
-		} else {
-			switch (type) {
-			case INTEGER: {
-					std::stringstream ss;
-					ss << *data.intValue;
-					return ss.str();
-				}
-
-			case DOUBLE: {
-					std::stringstream ss;
-					ss << *data.doubleValue;
-					return ss.str();
-				}
-
-			case BOOLEAN:
-				return (*data.boolValue) ? (Literals::TRUE_STRING) : (Literals::FALSE_STRING);
-
-			case NULL_VALUE:
-				return Literals::NULL_STRING;
-
-			default:
-				return std::string();
+		case INTEGER: {
+				std::stringstream ss;
+				ss << *data.intValue;
+				return ss.str();
 			}
-		}
+
+		case DOUBLE: {
+				std::stringstream ss;
+				ss << *data.doubleValue;
+				return ss.str();
+			}
+
+		case BOOLEAN:
+			return (*data.boolValue) ? (Literals::TRUE_STRING) : (Literals::FALSE_STRING);
+
+		case OBJECT:
+		case ARRAY: {
+				std::stringstream ss;
+				ss << *this;
+				return ss.str();
+			}
+
+		case NULL_VALUE:
+			return Literals::NULL_STRING;
+
+		default:
+			return std::string();
 	}
+}
 
 	void Value::setString(std::string const &newString) {
 		if (type == STRING) {


### PR DESCRIPTION
Calling this method is a workaround for std::cout not being thread-safe with JsonBox.
See #43 for details.
The following code will be thread safe under this pull request:
```c++
JsonBox::Value val;
val["test"] = 1;
std::cout << val.getToString() << std::endl;
```